### PR TITLE
Enable Source Link and embed debug info

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="CSharpAnalyzers" Version="1.5.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />    
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="[8.0.0.0,)" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.7.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.7.3" />
     <PackageVersion Include="RestSharp" Version="112.0.0" />

--- a/src/RestSharp.RequestBuilder/RestSharp.RequestBuilder.csproj
+++ b/src/RestSharp.RequestBuilder/RestSharp.RequestBuilder.csproj
@@ -22,5 +22,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updated `Directory.Build.props` to embed debug info directly into the assembly by adding `<DebugType>embedded</DebugType>`. Added `Microsoft.SourceLink.GitHub` version `[8.0.0.0,)` to `Directory.Packages.props` to enable Source Link for source code debugging. Modified `RestSharp.RequestBuilder.csproj` to include `Microsoft.SourceLink.GitHub` with `PrivateAssets="All"` to ensure it is used during the build but not exposed as a dependency.