### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,6 @@
 name: "CI: Build and Test"
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/brandonhenricks/RestSharp.RequestBuilder/security/code-scanning/3](https://github.com/brandonhenricks/RestSharp.RequestBuilder/security/code-scanning/3)

To fix this issue, add a `permissions` block specifying minimal required GITHUB_TOKEN permissions at the root of the workflow in `.github/workflows/dotnet.yml`. The best practice is to set `contents: read` if no steps require write access to repository contents, issues, or pull-requests. This will ensure all jobs in the workflow inherit the least permissions required. Insert the block directly after the workflow `name` and before the `on:` section (i.e. after line 1) for maximum clarity and maintainability. No other changes or dependencies are needed. If in the future any step requires additional privileges, those can be granted at job-level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
