### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Nuget Release
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/brandonhenricks/RestSharp.RequestBuilder/security/code-scanning/1](https://github.com/brandonhenricks/RestSharp.RequestBuilder/security/code-scanning/1)

- **General fix:** Add the `permissions` key to the workflow or job definition to restrict the GitHub Actions runner token's privileges to the minimum necessary. In this case, only `contents: read` is strictly needed (to check out code).
- **Best way:** Place the `permissions` key at the top level of the workflow file, just below the workflow name or before `on:` (either is OK, but after the name is standard). This will restrict permissions for all jobs unless overridden.
- **Detail:** Insert a `permissions:` block with `contents: read` as the only entry beneath the `name` property and before the `on:` property in `.github/workflows/publish.yml`. No additional imports, method, or variable definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
